### PR TITLE
fix(yarn): ignore engines when installing dependencies due to RTCMultiConnection

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+ignore-engines true

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Visit https://2N.fm/{{room-name-here}} to view someone else's tab.
 
 ## Project setup
 ```
-yarn install --no-engines
+yarn
 ```
 
 ### Compiles and hot-reloads for development


### PR DESCRIPTION
This is not the desired fix and probably here for documentation purposes -- as discussed with @codysherman, we probably just want RTCMultiConnection to do another release as they've fixed the problem upstream but without releasing to NPM.

Feel free to accept, or to decline once a better solution is found.

Resolves #69 