### PR TITLE
Removed NO MORE update in hide and show stats per #74

### DIFF
--- a/src/components/ReceiverConnection.vue
+++ b/src/components/ReceiverConnection.vue
@@ -151,6 +151,7 @@ export default {
       if (e.userid !== this.roomName) return;
 
       // TODO: maybe split into SOCKET_WILL_CLOSE so we can update infoBarMessage before closing
+      this.stats.nomore();
       this.connection.close();
       this.connection.closeSocket();
       this.connection.userid = this.connection.token();
@@ -227,6 +228,7 @@ export default {
         event.iceConnectionState === 'connected' &&
         event.signalingState === 'stable'
       ) {
+        console.log(event.iceConnectionState);
         if (dontDuplicate[event.userid]) return;
         dontDuplicate[event.userid] = true;
 

--- a/src/views/Receiver.vue
+++ b/src/views/Receiver.vue
@@ -264,7 +264,7 @@ export default {
       false,
     );
   },
-  
+
   methods: {
     onConnectionStateChanged(state) {
       switch (state.value) {
@@ -397,11 +397,9 @@ export default {
     },
     showStats() {
       this.statsVisible = true;
-      this.NO_MORE = false;
     },
     hideStats() {
       this.statsVisible = false;
-      this.NO_MORE = true;
     },
     bytesToSize(bytes) {
       // TODO: Should this be 1024?

--- a/src/views/Receiver.vue
+++ b/src/views/Receiver.vue
@@ -80,6 +80,8 @@ video
 
 #volume-slider
   max-width: 120px
+  @supports (-webkit-touch-callout: none) // iOS volume slider doesn't work, so hide it
+    visibility: hidden
 
 #fullscreen-button,
 #theater-button
@@ -217,8 +219,6 @@ export default {
       isPlaying: false,
       theaterMode: false,
       statsVisible: false,
-      volume: window.localStorage.getItem('volume') || 0.5,
-      NO_MORE: false,
       stats: {},
       infoBarMessage: '',
       // set by Receiver.onPresenceCheckWait / Connection(@presenceCheckWait)
@@ -323,6 +323,7 @@ export default {
         break;
       case ReceiverConnection.STATE.DISCONNECTED:
         this.isStream = false;
+
         this.infoBarMessage = 'You\'ve been disconnected. Please try again.';
         break;
       case ReceiverConnection.STATE.GENERIC:
@@ -354,10 +355,6 @@ export default {
       this.presenceCheckWait = newValue;
     },
     onStats(stats) {
-      if (this.NO_MORE) {
-        stats.nomore();
-        return;
-      }
       this.stats = stats;
     },
     async playMedia() {
@@ -402,14 +399,13 @@ export default {
       this.statsVisible = false;
     },
     bytesToSize(bytes) {
-      // TODO: Should this be 1024?
-      var k = 1000;
-      var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+      let k = 1000;
+      let sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
       if (bytes === 0) {
         return '0 Bytes';
       }
-      var i = parseInt(Math.floor(Math.log(bytes) / Math.log(k)), 10);
-      return (bytes / Math.pow(k, i)).toPrecision(3) + ' ' + sizes[i];
+      let i = parseInt(Math.floor(Math.log(bytes) / Math.log(k)), 10);
+      return `${(bytes / Math.pow(k, i)).toPrecision(3)} ${sizes[i]}`;
     },
   },
 };


### PR DESCRIPTION
Co-authored-by: Eric Marcanio <ericmarcanio@gmail.com>
Co-authored-by: Matthew Phipps <mnphipps98@gmail.com>

Looks like there was no reason to update this.NO_MORE in hideStats() unless hideStats() is a misnomer.  