### PR TITLE
Fixed pause button being invisible while playing

### DIFF
--- a/src/views/Receiver.vue
+++ b/src/views/Receiver.vue
@@ -156,7 +156,7 @@ video
       .frow.nowrap
         button#play-button-container.frow.nowrap.button-none(
           type="button"
-          v-if="(stream.isAudio) || (stream.isVideo && !isPlaying)"
+          v-if="stream.isAudio || stream.isVideo"
           @click="togglePlayback"
         )
           PlaySvg(v-if="!isPlaying")

--- a/src/views/Receiver.vue
+++ b/src/views/Receiver.vue
@@ -83,7 +83,19 @@ video
   @supports (-webkit-touch-callout: none) // iOS volume slider doesn't work, so hide it
     visibility: hidden
 
-#fullscreen-button,
+#fullscreen-button
+  svg
+    width: 30px
+    fill: $primary-color
+    transition: transform 0.4s
+
+  &:hover,
+  &:active,
+  &:focus
+    transform: scale(1.1)
+  @supports (-webkit-touch-callout: none) // fullscreen API doesn't work on iOS, so hide it
+    visibility: hidden
+
 #theater-button
   svg
     width: 30px


### PR DESCRIPTION
Closes issue #116 . Also hides fullscreen button on iOS because it both causes issues with wrapping and doesn't work since iOS doesn't support Fullscreen API.
Credit to @jaelder2 for fix