### PR TITLE
Removed NO MORE update in hide and show stats per #74

### DIFF
--- a/src/components/ReceiverConnection.vue
+++ b/src/components/ReceiverConnection.vue
@@ -229,7 +229,6 @@ export default {
         event.iceConnectionState === 'connected' &&
         event.signalingState === 'stable'
       ) {
-        console.log(event.iceConnectionState);
         if (dontDuplicate[event.userid]) return;
         dontDuplicate[event.userid] = true;
 

--- a/src/components/ReceiverConnection.vue
+++ b/src/components/ReceiverConnection.vue
@@ -151,6 +151,7 @@ export default {
       if (e.userid !== this.roomName) return;
 
       // TODO: maybe split into SOCKET_WILL_CLOSE so we can update infoBarMessage before closing
+      this.stats.nomore();
       this.connection.close();
       this.connection.closeSocket();
       this.connection.userid = this.connection.token();
@@ -228,6 +229,7 @@ export default {
         event.iceConnectionState === 'connected' &&
         event.signalingState === 'stable'
       ) {
+        console.log(event.iceConnectionState);
         if (dontDuplicate[event.userid]) return;
         dontDuplicate[event.userid] = true;
 

--- a/src/views/Receiver.vue
+++ b/src/views/Receiver.vue
@@ -256,7 +256,6 @@ export default {
       theaterMode: false,
       statsVisible: false,
       volume: window.localStorage.getItem('volume') || 0.5,
-      NO_MORE: false,
       stats: {},
       infoBarMessage: '',
       // set by Receiver.onPresenceCheckWait / Connection(@presenceCheckWait)
@@ -356,6 +355,7 @@ export default {
         break;
       case ReceiverConnection.STATE.DISCONNECTED:
         this.isStream = false;
+
         this.infoBarMessage = 'You\'ve been disconnected. Please try again.';
         break;
       case ReceiverConnection.STATE.GENERIC:
@@ -392,10 +392,6 @@ export default {
       this.receiverViewerCount = count;
     },
     onStats(stats) {
-      if (this.NO_MORE) {
-        stats.nomore();
-        return;
-      }
       this.stats = stats;
     },
     async playMedia() {

--- a/src/views/Receiver.vue
+++ b/src/views/Receiver.vue
@@ -439,11 +439,9 @@ export default {
     },
     showStats() {
       this.statsVisible = true;
-      this.NO_MORE = false;
     },
     hideStats() {
       this.statsVisible = false;
-      this.NO_MORE = true;
     },
     bytesToSize(bytes) {
       let k = 1000;


### PR DESCRIPTION
Co-authored-by: Eric Marcanio ericmarcanio@gmail.com
Co-authored-by: Matthew Phipps mnphipps98@gmail.com

Looks like there was no reason to update this.NO_MORE in hideStats() unless hideStats() is a misnomer.

_Originally posted by @andmarek in #102_