### PR TITLE
Fix WebRTC Adapter URL

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,7 +32,7 @@
     <!-- expected by RTCMultiConnection-->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.3.0/socket.io.js"></script>
     <!-- needs to be imported for back-compat, but not referenced -->
-    <script src="https://unpkg.com/webrtc-adapter@7.5.0/dist/adapter-core.js"></script>
+    <script src="https://unpkg.com/webrtc-adapter@7.5.0/out/adapter.js"></script>
     <!-- NOTE: needs to be loaded via CDN due to cached module exports not working
          solves issue where you cannot construct a connection from multiple files without refresh
     -->


### PR DESCRIPTION
This should only affect older browsers -- fixed a bad URL + importing the wrong file from NPM (the ES Module rather than the compiled output).