### PR TITLE
P2P only streams + h.264 support

### DIFF
--- a/src/components/Player/MediaControls.vue
+++ b/src/components/Player/MediaControls.vue
@@ -1,7 +1,7 @@
 <style scoped lang="sass">
 .media-controls
   width: 60%
-  animation: fade-in 0.4s
+  animation: fade-in $animate-speed
 
   .play-button-container
     width: 30px
@@ -27,7 +27,7 @@
   svg
     width: 18px
     fill: $primary-color
-    transition: transform 0.4s
+    transition: transform $animate-speed
 
   &:hover,
   &:active,
@@ -38,7 +38,7 @@
   svg
     width: 30px
     fill: $primary-color
-    transition: transform 0.4s
+    transition: transform $animate-speed
 
   &:hover,
   &:active,

--- a/src/components/ReceiverConnection.vue
+++ b/src/components/ReceiverConnection.vue
@@ -77,15 +77,6 @@ export default {
       OfferToReceiveVideo: true,
     };
 
-    this.connection.candidates = {
-      stun: true,
-      turn: true,
-    };
-    this.connection.iceTransportPolicy = 'relay';
-
-    this.connection.getExternalIceServers = false;
-    this.connection.iceServers = IceServersHandler.getIceServers();
-
     this.connection.processSdp = (sdp) => {
       var bandwidth = this.params.bandwidth;
       var codecs = this.params.codecs;
@@ -145,6 +136,16 @@ export default {
       if (e.extra.systemAudioId) {
         e.stream.systemAudioId = e.extra.systemAudioId;
       }
+
+      this.connection.candidates = {
+        stun: true,
+        turn: !e.extra.isP2POnly,
+      };
+      this.connection.iceTransportPolicy = 'all';
+
+      this.connection.getExternalIceServers = false;
+      this.connection.iceServers = IceServersHandler.getIceServers(!e.extra.isP2POnly);
+
       this.$emit('stream', e.stream);
     };
 

--- a/src/components/StreamerConnection.vue
+++ b/src/components/StreamerConnection.vue
@@ -38,6 +38,10 @@ export default {
       type: Boolean,
       default: false, 
     },
+    isP2POnly: {
+      type: Boolean,
+      default: false,
+    },
   },  
   data() {
     return {
@@ -83,9 +87,9 @@ export default {
 
       this.connection.candidates = {
         stun: true,
-        turn: true,
+        turn: !this.isP2POnly,
       };
-      this.connection.iceTransportPolicy = 'relay';
+      this.connection.iceTransportPolicy = 'all';
 
       this.connection.iceProtocols = {
         tcp: true,
@@ -106,7 +110,8 @@ export default {
       this.connection.autoReDialOnFailure = true;
       this.connection.getExternalIceServers = false;
 
-      this.connection.iceServers = IceServersHandler.getIceServers();
+      this.connection.extra.isP2POnly = this.isP2POnly;
+      this.connection.iceServers = IceServersHandler.getIceServers(!this.isP2POnly);
 
       this.connection.processSdp = (sdp) => {
         if (this.bandwidth) {

--- a/src/utils/background/helpers/IceServersHandler.js
+++ b/src/utils/background/helpers/IceServersHandler.js
@@ -1,12 +1,18 @@
 // IceServersHandler.js
 
+const TURN_USERNAME =
+  'paB_VapMS4rh7KG1WxSX5sAoEAzPCBei0AwjO-PLRjIGrYBCsFZ_9WF-XlAvTnIBAAAAAF2FRx5jb2R5c2hlcm1hbg==';
+const TURN_CREDENTIAL = '282dd8fc-dbef-11e9-87d1-12339b8f6738';
+
 export const IceServersHandler = (function() {
-  function getIceServers() {
+  function getIceServers(withTurn = true) {
     var iceServers = [{
       urls: [ 'stun:ws-turn1.xirsys.com' ],
-    }, {
-      username: 'paB_VapMS4rh7KG1WxSX5sAoEAzPCBei0AwjO-PLRjIGrYBCsFZ_9WF-XlAvTnIBAAAAAF2FRx5jb2R5c2hlcm1hbg==',
-      credential: '282dd8fc-dbef-11e9-87d1-12339b8f6738',
+    }];
+
+    if (withTurn) iceServers.push({
+      username: TURN_USERNAME,
+      credential: TURN_CREDENTIAL,
       urls: [
         'turn:ws-turn1.xirsys.com:80?transport=udp',
         'turn:ws-turn1.xirsys.com:3478?transport=udp',
@@ -15,7 +21,7 @@ export const IceServersHandler = (function() {
         'turns:ws-turn1.xirsys.com:443?transport=tcp',
         'turns:ws-turn1.xirsys.com:5349?transport=tcp',
       ],
-    }];
+    });
 
     return iceServers;
   }

--- a/src/views/Receiver.vue
+++ b/src/views/Receiver.vue
@@ -40,7 +40,6 @@
   100%
     stroke-dashoffset: 0
 
-
 #loading-logo path
   stroke: $secondary-color
   stroke-width: 1.5

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -75,7 +75,7 @@
     left: 30px
     background-color: $white
     border: 2px solid $white
-    border-radius: 10px
+    border-radius: $border-radius-small
     padding: 0 8px
     width: auto
     z-index: 2
@@ -83,6 +83,7 @@
     &.right-item
       left: auto
       right: 30px
+      cursor: pointer
 
       svg
         width: 8px
@@ -91,20 +92,22 @@
         margin: 0 4px
         margin-bottom: 2px
 
-  .advanced, .advanced .frow
-    overflow: hidden
-    position: absolute
-    top: 0
-    right: 0
-    bottom: 0
-    left: 0
-    z-index: 1
+  .advanced
+    &,
+    & > .frow
+      overflow: hidden
+      position: absolute
+      top: 0
+      right: 0
+      bottom: 0
+      left: 0
+      z-index: 1
 
-  .advanced .frow
-    animation: slide-down 0.4s ease
-    background-color: $tertiary-color
-    border: 2px solid $tertiary-color
-    height: 100%
+    > .frow
+      animation: slide-down $animate-speed ease
+      background-color: $tertiary-color
+      border: 2px solid $tertiary-color
+      height: 100%
 
 .settings-item
   margin-bottom: 40px

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -103,8 +103,6 @@
     > .frow
       animation: slide-down $animate-speed ease
       background-color: $tertiary-color
-      border: 2px solid $tertiary-color
-      height: 100%
 
 .settings-item
   margin-bottom: 40px

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -74,11 +74,10 @@
     top: -9px
     left: 30px
     background-color: $white
-    border: 2px solid $white
     border-radius: $border-radius-small
-    padding: 0 8px
+    padding: 2px 10px
     width: auto
-    z-index: 2
+    z-index: $z-page
 
     &.right-item
       left: auto
@@ -86,22 +85,20 @@
       cursor: pointer
 
       svg
-        width: 8px
-        height: auto
-        display: inline
-        margin: 0 4px
-        margin-bottom: 2px
+        height: 8px
+        width: auto
+        margin: 0 4px 2px
 
   .advanced
+    overflow: hidden
+
     &,
     & > .frow
-      overflow: hidden
       position: absolute
       top: 0
       right: 0
       bottom: 0
       left: 0
-      z-index: 1
 
     > .frow
       animation: slide-down $animate-speed ease
@@ -201,17 +198,16 @@
       section#options
         .label Options
         .label.right-item(@click="showAdvancedOptions = !showAdvancedOptions")
-          span(v-if="!showAdvancedOptions")
+          div(v-if="!showAdvancedOptions")
             | ⚙
             sup !
-          span(v-if="showAdvancedOptions")
+          div(v-if="showAdvancedOptions")
             XSvg
         .advanced(v-show="showAdvancedOptions")
           .frow.centered
-            .col-xs-1-1
-              label.row-center
-                input(type="checkbox" v-model="isP2POnly")
-                | Only send audio and video via peer-to-peer connections
+            label.row-center.mb-0
+              input(type="checkbox" v-model="isP2POnly")
+              | Only send audio and video via peer-to-peer connections
         .frow.gutters
           .col-xs-1-2
             .settings-item

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -34,7 +34,7 @@
   margin-top: 0.5em
   border-radius: $border-radius-small
 
-/* XS
+/* XS */
 @media (max-width: 767px)
   #logo
     width: 114px
@@ -53,7 +53,7 @@
     font-size: 40px
     border-width: 4px
 
-/* XS
+/* XS */
 @media (max-width: 767px)
   #room-id-label
     font-size: 30px
@@ -74,8 +74,37 @@
     top: -9px
     left: 30px
     background-color: $white
+    border: 2px solid $white
+    border-radius: 10px
     padding: 0 8px
     width: auto
+    z-index: 2
+
+    &.rightItem
+      left: auto
+      right: 30px
+
+      svg
+        width: 8px
+        height: auto
+        display: inline
+        margin: 0 4px
+        margin-bottom: 2px
+
+  .advanced, .advanced .frow
+    overflow: hidden
+    position: absolute
+    top: 0
+    right: 0
+    bottom: 0
+    left: 0
+    z-index: 1
+
+  .advanced .frow
+    animation: slide-down 0.4s ease
+    background-color: $tertiary-color
+    border: 2px solid $tertiary-color
+    height: 100%
 
 .settings-item
   margin-bottom: 40px
@@ -143,6 +172,7 @@
     :privacy="privacy"
     :enableVideo="enableVideo"
     :enableAudio="enableAudio"
+    :isP2POnly="isP2POnly"
     @sessionId="onSessionId"
     @viewerCount="onViewerCount"
     @idTaken="onIdTaken"
@@ -167,6 +197,18 @@
           @blur="setRoomName")
       section#options
         .label Options
+        .label.rightItem(@click="showAdvancedOptions = !showAdvancedOptions")
+          span(v-if="!showAdvancedOptions")
+            | ⚙
+            sup !
+          span(v-if="showAdvancedOptions")
+            XSvg
+        .advanced(v-show="showAdvancedOptions")
+          .frow.centered
+            .col-xs-1-1
+              label.row-center
+                input(type="checkbox" v-model="isP2POnly")
+                | Only send audio and video via peer-to-peer connections
         .frow.gutters
           .col-xs-1-2
             .settings-item
@@ -198,7 +240,7 @@
                 //- option(value="default" selected="") Default (VP9)
                 option(:value="Codecs.vp9") VP9 (Screensharing)
                 option(:value="Codecs.vp8") VP8 (Gaming)
-                //- option(:value="Codecs.h264") H.264
+                option(:value="Codecs.h264" :disabled="!isP2POnly") H.264
             //- .text-center
               span(v-if="codecs === Codecs.vp9")
                 | Better quality, less data
@@ -221,6 +263,7 @@
           //-     label
           //-       | Room Password
           //-       input#room_password(type="password" value="" placeholder="Optional")
+      
       section#stream-section
         #start
           .label Start
@@ -264,6 +307,7 @@ import LogoSvg from '@/assets/svgs/logo.svg';
 import VideoSvg from '@/assets/svgs/video.svg';
 import AudioSvg from '@/assets/svgs/audio.svg';
 import VideoAndAudioSvg from '@/assets/svgs/video-and-audio.svg';
+import XSvg from '@/assets/svgs/x.svg';
 
 import StopSection from '@/components/Streamer/StopSection.vue';
 import DesktopCapturer from '@/components/DesktopCapturer.vue';
@@ -284,6 +328,7 @@ export default {
     VideoSvg,
     AudioSvg,
     VideoAndAudioSvg,
+    XSvg,
     StopSection,
     DesktopCapturer,
     StreamerConnection,
@@ -308,11 +353,21 @@ export default {
       privacy: 'private',
       useridAlreadyTaken: '',
       isMic: false,
+      showAdvancedOptions: false,
+      isP2POnly: false,
     };
   },
   computed: {
     Resolutions() { return Resolutions; },
     Codecs() { return Codecs; },
+  },
+  watch: {
+    isP2POnly(isP2POnly) {
+      if (!isP2POnly && this.codecs == Codecs.h264) {
+        // TODO: we may want to alert the user of this change somehow
+        this.codecs = Codecs.vp8;
+      }
+    },
   },
   mounted() {
     // document.getElementById('enable-chat').onclick = function() {

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -34,7 +34,7 @@
   margin-top: 0.5em
   border-radius: $border-radius-small
 
-/* XS */
+// XS
 @media (max-width: 767px)
   #logo
     width: 114px
@@ -53,7 +53,7 @@
     font-size: 40px
     border-width: 4px
 
-/* XS */
+// XS
 @media (max-width: 767px)
   #room-id-label
     font-size: 30px

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -83,6 +83,7 @@
       left: auto
       right: 30px
       cursor: pointer
+      user-select: none
 
       svg
         height: 8px

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -80,7 +80,7 @@
     width: auto
     z-index: 2
 
-    &.rightItem
+    &.right-item
       left: auto
       right: 30px
 
@@ -197,7 +197,7 @@
           @blur="setRoomName")
       section#options
         .label Options
-        .label.rightItem(@click="showAdvancedOptions = !showAdvancedOptions")
+        .label.right-item(@click="showAdvancedOptions = !showAdvancedOptions")
           span(v-if="!showAdvancedOptions")
             | ⚙
             sup !


### PR DESCRIPTION
Allow the streamer to specify a P2P only stream. If the streamer chooses P2P only, they now have the ability to stream via the h.264 codec.

Note that based on either how WebRTC, TURN servers, RTCPeerConnection, or RTCMultiConnection works, the receiver *must* play along and also not use the TURN server when configuring their connection :shrug: To accommodate this, the connection's `extra` parameters now contains `isP2POnly`, which instructs the ReceiverConnection to disable TURN functionality if set to a truthy value.

Closes #139 

Related: #146 