### PR TITLE
Duplicate room stream fixes

### DIFF
--- a/src/assets/sass/global.sass
+++ b/src/assets/sass/global.sass
@@ -9,7 +9,7 @@ input
 h1, h2, h3, h4, h5, h6
   font-weight: $weight-bold
 
-.text-bold
+strong
   font-weight: $weight-bold
 
 label,

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -176,10 +176,8 @@ div
       .live-indicator(:class="{ live: isSharingOn && sessionId }") LIVE
     .col-md-1-2
       div(v-if="!isSharingOn || !sessionId")
-        .id-taken(v-if="useridAlreadyTaken")
-          | Whoops,
-          b &nbsp;{{useridAlreadyTaken}}&nbsp;
-          | already taken! Please choose another room name.
+        .id-taken.text-center(v-if="useridAlreadyTaken === room_id")
+          | Room name already taken: #[strong {{useridAlreadyTaken}}]
         label.room-id-label.row-start
           span.shrink-0
             | 2n.fm/
@@ -439,7 +437,6 @@ export default {
     },
     onIdTaken(takenID) {
       this.useridAlreadyTaken = takenID;
-      this.room_id = '';
       this.stopStream();
     },
     onIsSharing(isSharing) {

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -440,6 +440,7 @@ export default {
     onIdTaken(takenID) {
       this.useridAlreadyTaken = takenID;
       this.room_id = '';
+      this.stopStream();
     },
     onIsSharing(isSharing) {
       this.isSharingOn = isSharing;

--- a/src/views/Streamer.vue
+++ b/src/views/Streamer.vue
@@ -398,7 +398,7 @@ export default {
 
       let protectedRoutes = ['streamer'];
       if (protectedRoutes.includes(this.room_id)) {
-        this.useridAlreadyTaken = 'streamer';
+        this.useridAlreadyTaken = this.room_id;
         return;
       }
       this.$nextTick(() => {


### PR DESCRIPTION
Stop the mediastream if room name taken, and improve the logic and display of the taken message.

Solves #107 