### PR TITLE
Missing text in dark mode bug fixed

### DIFF
--- a/src/assets/sass/global.sass
+++ b/src/assets/sass/global.sass
@@ -30,6 +30,9 @@ input
       &::-ms-thumb
         background: var(--inverse-color)
 
+a.text-underline
+  transition: color $theme-fade-speed
+
 h1, h2, h3, h4, h5, h6
   font-weight: $weight-bold
 

--- a/src/assets/sass/global.sass
+++ b/src/assets/sass/global.sass
@@ -30,9 +30,6 @@ input
       &::-ms-thumb
         background: var(--inverse-color)
 
-a.text-underline
-  transition: color $theme-fade-speed
-
 h1, h2, h3, h4, h5, h6
   font-weight: $weight-bold
 

--- a/src/components/Streamer/StopSection.vue
+++ b/src/components/Streamer/StopSection.vue
@@ -1,4 +1,7 @@
 <style scoped lang="sass">
+a.text-underline
+  color: var(--inverse-color)
+
 .public-link
   text-align: center
   display: inline-block

--- a/src/components/Streamer/StopSection.vue
+++ b/src/components/Streamer/StopSection.vue
@@ -1,5 +1,6 @@
 <style scoped lang="sass">
 a.text-underline
+  transition: color $theme-fade-speed
   color: var(--inverse-color)
 
 .public-link


### PR DESCRIPTION
Closes #238 

Fixed the bug that didn't allow the text to change when the dark mode was activated.

Before this fix, the text stayed in the same color when the mode was switched into dark mode and it gave the impression that it had disappeared.

The underline element that marks that it is a link, had a conflict that override the class that allows to change when the dark mode is activated, so, I created a class to the underline element that applies this change.

![Screen Shot 2021-12-16 at 5 31 42 p m](https://user-images.githubusercontent.com/63618776/146469014-4d9e065c-dd47-406c-93a2-a78d10dd6ff4.png)
On the component "StopSection" where this text is placed we have this underline element that has the conflict with the switch color class.

![Screen Shot 2021-12-16 at 5 34 14 p m](https://user-images.githubusercontent.com/63618776/146469221-96629087-6651-41d3-87e0-33147360f916.png)
This is the class that I added to apply the change when the theme is switched

